### PR TITLE
feat: add horizontal swipe-to-seek with sprite preview in StashTok

### DIFF
--- a/stashy.xcodeproj/project.pbxproj
+++ b/stashy.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		02B19A59AAFE4A16B45A861F /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF22BB172F16743C007C2090 /* DownloadsView.swift */; };
+		DFSP00022F50SPRITE002 /* SpritePreviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */; };
+		DFSP00032F50SPRITE003 /* SpritePreviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */; };
 		08FB7793FE84155DC02AAC07 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7794FE84155DC02AAC07 /* App.swift */; };
 		08FB7797FE84155DC02AAC07 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7798FE84155DC02AAC07 /* MainTabView.swift */; };
 		08FB779DFE84155DC02AAC07 /* ServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* ServerConfig.swift */; };
@@ -159,6 +161,7 @@
 
 /* Begin PBXFileReference section */
 		08FB7794FE84155DC02AAC07 /* App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpritePreviewManager.swift; sourceTree = "<group>"; };
 		08FB7798FE84155DC02AAC07 /* MainTabView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		08FB779EFE84155DC02AAC07 /* ServerConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
 		08FB77A0FE84155DC02AAC07 /* stashy/Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = stashy/Info.plist; sourceTree = "<group>"; };
@@ -302,6 +305,7 @@
 				372E2D692F6339EE00603361 /* LoginAuthHelper.swift */,
 				DF22BB262F167CDC007C2090 /* ImageCacheManager.swift */,
 				37BE5B4D2F51718500107960 /* Managers */,
+				DFSP00042F50SPRITE004 /* Utilities */,
 				DFSM000022F2NEWFILE002 /* KeychainManager.swift */,
 				08FB7798FE84155DC02AAC07 /* MainTabView.swift */,
 				DF22BB352F1832AD007C2090 /* NavigationCoordinator.swift */,
@@ -342,6 +346,14 @@
 				DFSEC0022F2A000100000002 /* SecurityManager.swift */,
 			);
 			path = Managers;
+			sourceTree = "<group>";
+		};
+		DFSP00042F50SPRITE004 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 		DF675E612F2A46A1004CA019 /* Home */ = {
@@ -646,6 +658,7 @@
 				DFSEC0012F2A000100000001 /* SecurityManager.swift in Sources */,
 				DFSEC0032F2A000100000003 /* PasscodeEntryView.swift in Sources */,
 				DFSEC0052F2A000100000005 /* SecuritySettingsView.swift in Sources */,
+				DFSP00022F50SPRITE002 /* SpritePreviewManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -704,6 +717,7 @@
 				C047CE6380F048858A91E6C9 /* GraphQLClient.swift in Sources */,
 				C047CE6380F048858A91E6CA /* TrustAllSessionDelegate.swift in Sources */,
 				E909C6E8F4744C4D939F78BD /* GraphQLQueries.swift in Sources */,
+				DFSP00032F50SPRITE003 /* SpritePreviewManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/stashy/ReelsView.swift
+++ b/stashy/ReelsView.swift
@@ -1118,6 +1118,27 @@ struct ReelsView: View {
             }
         }
 
+        var videoAspectRatio: CGFloat? {
+            let file: SceneFile?
+            switch self {
+            case .scene(let s): file = s.files?.first
+            case .marker(let m): file = m.scene?.files?.first
+            case .preview(let s): file = s.files?.first
+            case .clip: file = nil
+            }
+            guard let w = file?.width, let h = file?.height, w > 0, h > 0 else { return nil }
+            return CGFloat(w) / CGFloat(h)
+        }
+
+        var spritePaths: (vtt: String?, sprite: String?) {
+            switch self {
+            case .scene(let s): return (s.paths?.vtt, s.paths?.sprite)
+            case .marker(let m): return (m.scene?.paths?.vtt, m.scene?.paths?.sprite)
+            case .preview(let s): return (s.paths?.vtt, s.paths?.sprite)
+            case .clip: return (nil, nil)
+            }
+        }
+
     }
 
     private var currentReelItems: [ReelItemData] {
@@ -3354,6 +3375,9 @@ struct ReelItemView: View {
     @State private var isFastForwarding = false
     var onInteraction: () -> Void
     @StateObject private var videoSurfaceReadiness = ReelItemVideoSurfaceReadiness()
+    @StateObject private var spritePreview = SpritePreviewManager()
+    @State private var isSwipeSeeking = false
+    @State private var seekTimeOffset: Double = 0
 
     private var shouldFill: Bool {
         // Only fill if the setting is enabled
@@ -3379,6 +3403,8 @@ struct ReelItemView: View {
     private var mainContent: some View {
         ZStack(alignment: .bottom) {
             mediaLayer
+            seekPreviewOverlay
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             fastForwardOverlay
             playButtonOverlay
             bottomBarOverlay
@@ -3572,7 +3598,7 @@ extension ReelItemView {
 
     @ViewBuilder
     private var mediaLayer: some View {
-        ZoomableScrollView(isZoomed: $isZoomed, onTap: handleMediaTap, onLongPress: handleLongPress) {
+        ZoomableScrollView(isZoomed: $isZoomed, onTap: handleMediaTap, onLongPress: handleLongPress, onHorizontalPan: handleSeekPan) {
             ZStack {
                 Group {
                     if item.isAnimated {
@@ -3664,6 +3690,103 @@ extension ReelItemView {
             }
         }
         onInteraction()
+    }
+
+    private func handleSeekPan(translation: CGFloat, state: UIGestureRecognizer.State) {
+        guard !item.isAnimated else { return }
+        let screenWidth = UIScreen.main.bounds.width
+        let deadzone: CGFloat = 20
+
+        switch state {
+        case .began, .changed:
+            let absTrans = abs(translation)
+            if absTrans < deadzone {
+                seekTimeOffset = 0
+                if isSwipeSeeking {
+                    withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = false }
+                }
+            } else {
+                let progress = min((absTrans - deadzone) / (screenWidth - deadzone), 1.0)
+                let seconds = 10.0 + Double(progress) * 1190.0
+                seekTimeOffset = translation > 0 ? seconds : -seconds
+                seekTimeOffset = max(-scrubberState.time, min(seekTimeOffset, scrubberState.duration - scrubberState.time))
+                if !isSwipeSeeking {
+                    withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = true }
+                }
+            }
+
+        case .ended:
+            if isSwipeSeeking && abs(seekTimeOffset) >= 10 {
+                let targetTime = max(0, min(scrubberState.time + seekTimeOffset, scrubberState.duration))
+                seek(to: targetTime)
+                onInteraction()
+            }
+            withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = false }
+            seekTimeOffset = 0
+
+        case .cancelled, .failed:
+            withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = false }
+            seekTimeOffset = 0
+
+        default:
+            break
+        }
+    }
+
+    private func formatSeekOffset(_ seconds: Double) -> String {
+        let sign = seconds >= 0 ? "+" : "-"
+        let abs = abs(seconds)
+        let m = Int(abs) / 60
+        let s = Int(abs) % 60
+        return "\(sign)\(m):\(String(format: "%02d", s))"
+    }
+
+    private func formatTimestamp(_ seconds: Double) -> String {
+        let clamped = max(0, seconds)
+        let m = Int(clamped) / 60
+        let s = Int(clamped) % 60
+        return "\(m):\(String(format: "%02d", s))"
+    }
+
+    private var seekPreviewSize: CGSize {
+        let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+        let maxDim: CGFloat = isLandscape ? 120 : 140
+        let ratio = item.videoAspectRatio ?? 16.0 / 9.0
+        if ratio >= 1 {
+            return CGSize(width: maxDim, height: maxDim / ratio)
+        } else {
+            return CGSize(width: maxDim * ratio, height: maxDim)
+        }
+    }
+
+    @ViewBuilder
+    private var seekPreviewOverlay: some View {
+        if isSwipeSeeking {
+            let targetTime = max(0, min(scrubberState.time + seekTimeOffset, scrubberState.duration))
+            let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+            let previewSize = seekPreviewSize
+            VStack(alignment: .leading, spacing: 4) {
+                if let frame = spritePreview.frameImage(at: targetTime) {
+                    Image(uiImage: frame)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: previewSize.width, height: previewSize.height)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                Text(formatSeekOffset(seekTimeOffset))
+                    .font(.system(size: isLandscape ? 17 : 20, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white)
+                Text("→ \(formatTimestamp(targetTime))")
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .padding(10)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.top, isLandscape ? 16 : 80)
+            .padding(.leading, isLandscape ? 60 : 16)
+            .transition(.opacity)
+        }
     }
 
     @ViewBuilder
@@ -3811,6 +3934,9 @@ extension ReelItemView {
     func setupPlayer() {
         // Animations don't need AVPlayer
         guard !item.isAnimated else { return }
+
+        let paths = item.spritePaths
+        spritePreview.load(vttURLString: paths.vtt, spriteURLString: paths.sprite)
 
         // `onAppear` + scroll settle can both call `setupPlayer` in the same transition; avoid a second
         // `initPlayer`/generation bump (visible flash + duplicate stream work).

--- a/stashy/ReelsView.swift
+++ b/stashy/ReelsView.swift
@@ -3733,14 +3733,6 @@ extension ReelItemView {
         }
     }
 
-    private func formatSeekOffset(_ seconds: Double) -> String {
-        let sign = seconds >= 0 ? "+" : "-"
-        let abs = abs(seconds)
-        let m = Int(abs) / 60
-        let s = Int(abs) % 60
-        return "\(sign)\(m):\(String(format: "%02d", s))"
-    }
-
     private func formatTimestamp(_ seconds: Double) -> String {
         let clamped = max(0, seconds)
         let m = Int(clamped) / 60
@@ -3748,9 +3740,15 @@ extension ReelItemView {
         return "\(m):\(String(format: "%02d", s))"
     }
 
+    private var seekPreviewScale: CGFloat {
+        let shortEdge = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
+        return max(1.0, shortEdge / 390)
+    }
+
     private var seekPreviewSize: CGSize {
         let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
-        let maxDim: CGFloat = isLandscape ? 120 : 140
+        let scale = seekPreviewScale
+        let maxDim: CGFloat = (isLandscape ? 120 : 140) * scale
         let ratio = item.videoAspectRatio ?? 16.0 / 9.0
         if ratio >= 1 {
             return CGSize(width: maxDim, height: maxDim / ratio)
@@ -3764,26 +3762,25 @@ extension ReelItemView {
         if isSwipeSeeking {
             let targetTime = max(0, min(scrubberState.time + seekTimeOffset, scrubberState.duration))
             let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+            let scale = seekPreviewScale
+            let textScale = sqrt(scale)
             let previewSize = seekPreviewSize
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 4 * textScale) {
                 if let frame = spritePreview.frameImage(at: targetTime) {
                     Image(uiImage: frame)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: previewSize.width, height: previewSize.height)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .clipShape(RoundedRectangle(cornerRadius: 8 * scale))
                 }
-                Text(formatSeekOffset(seekTimeOffset))
-                    .font(.system(size: isLandscape ? 17 : 20, weight: .bold, design: .monospaced))
+                Text(formatTimestamp(targetTime))
+                    .font(.system(size: (isLandscape ? 17 : 20) * textScale, weight: .bold, design: .monospaced))
                     .foregroundColor(.white)
-                Text("→ \(formatTimestamp(targetTime))")
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.7))
             }
-            .padding(10)
+            .padding(10 * textScale)
             .background(.ultraThinMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.top, isLandscape ? 16 : 80)
+            .clipShape(RoundedRectangle(cornerRadius: 12 * textScale))
+            .padding(.top, (isUIVisible ? (isLandscape ? 60 : 120) : (isLandscape ? 16 : 80)) * scale)
             .padding(.leading, isLandscape ? 60 : 16)
             .transition(.opacity)
         }

--- a/stashy/SharedUtilities.swift
+++ b/stashy/SharedUtilities.swift
@@ -402,16 +402,22 @@ struct AnimatedWebView: UIViewRepresentable {
 
 
 /// A wrapper around UIScrollView that provides pinch-to-zoom and panning for any SwiftUI view.
+class HorizontalSeekPanGesture: UIPanGestureRecognizer {
+    weak var scrollView: UIScrollView?
+}
+
 struct ZoomableScrollView<Content: View>: UIViewRepresentable {
     private var content: Content
     private var onTap: ((CGPoint) -> Void)?
     private var onLongPress: ((Bool) -> Void)?
+    private var onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)?
     @Binding var isZoomed: Bool
-    
-    init(isZoomed: Binding<Bool> = .constant(false), onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil, @ViewBuilder content: () -> Content) {
+
+    init(isZoomed: Binding<Bool> = .constant(false), onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil, onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)? = nil, @ViewBuilder content: () -> Content) {
         self._isZoomed = isZoomed
         self.onTap = onTap
         self.onLongPress = onLongPress
+        self.onHorizontalPan = onHorizontalPan
         self.content = content()
     }
     
@@ -455,32 +461,42 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
         let longPress = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
         longPress.minimumPressDuration = 0.3
         scrollView.addGestureRecognizer(longPress)
-        
+
+        #if !os(tvOS)
+        let seekPan = HorizontalSeekPanGesture(target: context.coordinator, action: #selector(Coordinator.handleSeekPan(_:)))
+        seekPan.scrollView = scrollView
+        seekPan.delegate = context.coordinator
+        scrollView.addGestureRecognizer(seekPan)
+        #endif
+
         return scrollView
     }
-    
+
     func updateUIView(_ uiView: UIScrollView, context: Context) {
         context.coordinator.hostingController.rootView = content
         context.coordinator.onTap = onTap
         context.coordinator.onLongPress = onLongPress
+        context.coordinator.onHorizontalPan = onHorizontalPan
         context.coordinator.isZoomed = $isZoomed
     }
-    
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(hostingController: UIHostingController(rootView: content), isZoomed: $isZoomed, onTap: onTap, onLongPress: onLongPress)
+        Coordinator(hostingController: UIHostingController(rootView: content), isZoomed: $isZoomed, onTap: onTap, onLongPress: onLongPress, onHorizontalPan: onHorizontalPan)
     }
     
-    class Coordinator: NSObject, UIScrollViewDelegate {
+    class Coordinator: NSObject, UIScrollViewDelegate, UIGestureRecognizerDelegate {
         var hostingController: UIHostingController<Content>
         var isZoomed: Binding<Bool>
         var onTap: ((CGPoint) -> Void)?
         var onLongPress: ((Bool) -> Void)?
-        
-        init(hostingController: UIHostingController<Content>, isZoomed: Binding<Bool>, onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil) {
+        var onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)?
+
+        init(hostingController: UIHostingController<Content>, isZoomed: Binding<Bool>, onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil, onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)? = nil) {
             self.hostingController = hostingController
             self.isZoomed = isZoomed
             self.onTap = onTap
             self.onLongPress = onLongPress
+            self.onHorizontalPan = onHorizontalPan
         }
         
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -517,6 +533,23 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
             }
         }
         
+        @objc func handleSeekPan(_ gesture: UIPanGestureRecognizer) {
+            let translation = gesture.translation(in: gesture.view)
+            onHorizontalPan?(translation.x, gesture.state)
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let seekPan = gestureRecognizer as? HorizontalSeekPanGesture else { return true }
+            guard let scrollView = seekPan.scrollView, scrollView.zoomScale <= 1.01 else { return false }
+            let vel = seekPan.velocity(in: seekPan.view)
+            return abs(vel.x) > abs(vel.y) * 1.5
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            if gestureRecognizer is HorizontalSeekPanGesture { return true }
+            return false
+        }
+
         @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
             guard let scrollView = gesture.view as? UIScrollView else { return }
             

--- a/stashy/Utilities/SpritePreviewManager.swift
+++ b/stashy/Utilities/SpritePreviewManager.swift
@@ -1,0 +1,175 @@
+import UIKit
+
+struct VTTEntry {
+    let startTime: Double
+    let endTime: Double
+    let x: Int
+    let y: Int
+    let width: Int
+    let height: Int
+}
+
+@MainActor
+class SpritePreviewManager: ObservableObject {
+    @Published var spriteImage: UIImage?
+    @Published var isLoaded = false
+
+    private var vttEntries: [VTTEntry] = []
+    private var loadTask: Task<Void, Never>?
+
+    func load(vttURLString: String?, spriteURLString: String?) {
+        loadTask?.cancel()
+        vttEntries = []
+        spriteImage = nil
+        isLoaded = false
+
+        guard let vttStr = vttURLString, let spriteStr = spriteURLString,
+              let vttURL = URL(string: vttStr), let spriteURL = URL(string: spriteStr) else { return }
+
+        let signedVTT = signedURL(vttURL) ?? vttURL
+        let signedSprite = signedURL(spriteURL) ?? spriteURL
+
+        loadTask = Task {
+            do {
+                let entries = try await fetchAndParseVTT(url: signedVTT)
+                if Task.isCancelled { return }
+                self.vttEntries = entries
+
+                let image = try await fetchSpriteImage(url: signedSprite)
+                if Task.isCancelled { return }
+                self.spriteImage = image
+                self.isLoaded = true
+            } catch {
+                // Non-blocking: sprite preview is optional
+            }
+        }
+    }
+
+    func frameImage(at time: Double) -> UIImage? {
+        guard let sprite = spriteImage, let cgImage = sprite.cgImage else { return nil }
+        guard let entry = findEntry(for: time) else { return nil }
+
+        let scale = sprite.scale
+        let cropRect = CGRect(
+            x: CGFloat(entry.x) * scale,
+            y: CGFloat(entry.y) * scale,
+            width: CGFloat(entry.width) * scale,
+            height: CGFloat(entry.height) * scale
+        )
+        guard let cropped = cgImage.cropping(to: cropRect) else { return nil }
+        return UIImage(cgImage: cropped, scale: scale, orientation: .up)
+    }
+
+    private func findEntry(for time: Double) -> VTTEntry? {
+        guard !vttEntries.isEmpty else { return nil }
+        var lo = 0
+        var hi = vttEntries.count - 1
+        while lo <= hi {
+            let mid = (lo + hi) / 2
+            let entry = vttEntries[mid]
+            if time < entry.startTime {
+                hi = mid - 1
+            } else if time >= entry.endTime {
+                lo = mid + 1
+            } else {
+                return entry
+            }
+        }
+        if let last = vttEntries.last, time >= last.startTime {
+            return last
+        }
+        return vttEntries.first
+    }
+
+    // MARK: - Network
+
+    private func fetchAndParseVTT(url: URL) async throws -> [VTTEntry] {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        if let config = ServerConfigManager.shared.activeConfig,
+           let apiKey = config.secureApiKey, !apiKey.isEmpty {
+            request.addValue(apiKey, forHTTPHeaderField: "ApiKey")
+        }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+        return parseVTT(text)
+    }
+
+    private func fetchSpriteImage(url: URL) async throws -> UIImage? {
+        if let cached = ImageCache.shared.object(forKey: url as NSURL) {
+            return cached
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        if let config = ServerConfigManager.shared.activeConfig,
+           let apiKey = config.secureApiKey, !apiKey.isEmpty {
+            request.addValue(apiKey, forHTTPHeaderField: "ApiKey")
+        }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        guard let image = UIImage(data: data) else { return nil }
+        ImageCache.shared.setData(data, forKey: url as NSURL)
+        return image
+    }
+
+    // MARK: - VTT Parsing
+
+    private func parseVTT(_ text: String) -> [VTTEntry] {
+        var entries: [VTTEntry] = []
+        let lines = text.components(separatedBy: .newlines)
+        var i = 0
+
+        while i < lines.count {
+            let line = lines[i].trimmingCharacters(in: .whitespaces)
+            guard line.contains("-->") else { i += 1; continue }
+
+            let parts = line.components(separatedBy: "-->")
+            guard parts.count == 2 else { i += 1; continue }
+
+            let startTime = parseTimestamp(parts[0].trimmingCharacters(in: .whitespaces))
+            let endTime = parseTimestamp(parts[1].trimmingCharacters(in: .whitespaces))
+            guard let start = startTime, let end = endTime else { i += 1; continue }
+
+            i += 1
+            if i < lines.count {
+                let dataLine = lines[i].trimmingCharacters(in: .whitespaces)
+                if let entry = parseXYWH(dataLine, startTime: start, endTime: end) {
+                    entries.append(entry)
+                }
+            }
+            i += 1
+        }
+        return entries
+    }
+
+    private func parseTimestamp(_ str: String) -> Double? {
+        let components = str.components(separatedBy: ":")
+        guard components.count >= 2 else { return nil }
+
+        if components.count == 3 {
+            guard let h = Double(components[0]),
+                  let m = Double(components[1]),
+                  let s = Double(components[2]) else { return nil }
+            return h * 3600 + m * 60 + s
+        } else {
+            guard let m = Double(components[0]),
+                  let s = Double(components[1]) else { return nil }
+            return m * 60 + s
+        }
+    }
+
+    private func parseXYWH(_ line: String, startTime: Double, endTime: Double) -> VTTEntry? {
+        guard let hashIndex = line.firstIndex(of: "#") else { return nil }
+        let fragment = String(line[line.index(after: hashIndex)...])
+        guard fragment.hasPrefix("xywh=") else { return nil }
+
+        let values = fragment.dropFirst(5).components(separatedBy: ",")
+        guard values.count == 4,
+              let x = Int(values[0]),
+              let y = Int(values[1]),
+              let w = Int(values[2]),
+              let h = Int(values[3]) else { return nil }
+
+        return VTTEntry(startTime: startTime, endTime: endTime, x: x, y: y, width: w, height: h)
+    }
+}


### PR DESCRIPTION
Swipe left/right on a reel item to seek backward/forward (10s-20min range mapped to swipe distance). A preview overlay in the top-left shows the Stash scrubber sprite frame at the target position plus a time offset label. Sprite loading is async and non-blocking - seek works instantly even if the sprite sheet hasn't loaded yet.