### PR TITLE
Show tvOS some love

### DIFF
--- a/stashy.xcodeproj/project.pbxproj
+++ b/stashy.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		F0A11E1B0B0B0B0B0B0B0B01 /* PocketSVG in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F708192A3B4C5 /* PocketSVG */; };
 		F0A11E1B0B0B0B0B0B0B0B02 /* PocketSVG in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F708192A3B4C5 /* PocketSVG */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B1A2C3D4E5F60718293A4B5C5 /* KSPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = B1A2C3D4E5F60718293A4B5C4 /* KSPlayer */; };
+		B1A2C3D4E5F60718293A4B5C7 /* KSPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = B1A2C3D4E5F60718293A4B5C6 /* KSPlayer */; };
 		F21C93AC1160498EB0A17AF4 /* GalleryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF675E672F2A6386004CA019 /* GalleryRepository.swift */; };
 		F4BF2858338E42E6AA292FCC /* PerformersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF22BB392F1832E8007C2090 /* PerformersView.swift */; };
 		F6BC02EF04794FCAA2460E89 /* PerformerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF675E682F2A6386004CA019 /* PerformerRepository.swift */; };
@@ -261,6 +262,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B1A2C3D4E5F60718293A4B5C7 /* KSPlayer in Frameworks */,
 				F0A11E1B0B0B0B0B0B0B0B01 /* PocketSVG in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -462,6 +464,7 @@
 				F0A11E1B0B0B0B0B0B0B0B03 /* Embed Frameworks */,
 				37D3E24B2F3932C400AB8FAD /* Frameworks */,
 				37D3E24C2F3932C400AB8FAD /* Resources */,
+				B1A2C3D4E5F60718293A4B5C8 /* Patch Embedded Framework Bundle IDs */,
 			);
 			buildRules = (
 			);
@@ -472,6 +475,7 @@
 			);
 			name = stashyTV;
 			packageProductDependencies = (
+				B1A2C3D4E5F60718293A4B5C6 /* KSPlayer */,
 				1A2B3C4D5E6F708192A3B4C5 /* PocketSVG */,
 			);
 			productName = stashyTV;
@@ -557,6 +561,25 @@
 			shellScript = "$PROJECT_DIR/stashy/scripts/bump_version.sh \n";
 		};
 		E7F1C9B62F10EA1E004BBEB5 /* Patch Embedded Framework Bundle IDs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Patch Embedded Framework Bundle IDs";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$PROJECT_DIR\"/stashy/scripts/patch_embedded_framework_bundle_ids.sh\n";
+		};
+		B1A2C3D4E5F60718293A4B5C8 /* Patch Embedded Framework Bundle IDs */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -920,7 +943,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 699G2QY959;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "stashyTV-Info.plist";
@@ -962,7 +985,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 699G2QY959;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "stashyTV-Info.plist";
@@ -1046,6 +1069,11 @@
 			productName = PocketSVG;
 		};
 		B1A2C3D4E5F60718293A4B5C4 /* KSPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B1A2C3D4E5F60718293A4B5C2 /* XCRemoteSwiftPackageReference "KSPlayer" */;
+			productName = KSPlayer;
+		};
+		B1A2C3D4E5F60718293A4B5C6 /* KSPlayer */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B1A2C3D4E5F60718293A4B5C2 /* XCRemoteSwiftPackageReference "KSPlayer" */;
 			productName = KSPlayer;

--- a/stashy.xcodeproj/project.pbxproj
+++ b/stashy.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		02B19A59AAFE4A16B45A861F /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF22BB172F16743C007C2090 /* DownloadsView.swift */; };
+		DFSP00022F50SPRITE002 /* SpritePreviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */; };
+		DFSP00032F50SPRITE003 /* SpritePreviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */; };
 		08FB7793FE84155DC02AAC07 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7794FE84155DC02AAC07 /* App.swift */; };
 		08FB7797FE84155DC02AAC07 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7798FE84155DC02AAC07 /* MainTabView.swift */; };
 		08FB779DFE84155DC02AAC07 /* ServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* ServerConfig.swift */; };
@@ -159,6 +161,7 @@
 
 /* Begin PBXFileReference section */
 		08FB7794FE84155DC02AAC07 /* App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpritePreviewManager.swift; sourceTree = "<group>"; };
 		08FB7798FE84155DC02AAC07 /* MainTabView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		08FB779EFE84155DC02AAC07 /* ServerConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
 		08FB77A0FE84155DC02AAC07 /* stashy/Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = stashy/Info.plist; sourceTree = "<group>"; };
@@ -302,6 +305,7 @@
 				372E2D692F6339EE00603361 /* LoginAuthHelper.swift */,
 				DF22BB262F167CDC007C2090 /* ImageCacheManager.swift */,
 				37BE5B4D2F51718500107960 /* Managers */,
+				DFSP00042F50SPRITE004 /* Utilities */,
 				DFSM000022F2NEWFILE002 /* KeychainManager.swift */,
 				08FB7798FE84155DC02AAC07 /* MainTabView.swift */,
 				DF22BB352F1832AD007C2090 /* NavigationCoordinator.swift */,
@@ -342,6 +346,14 @@
 				DFSEC0022F2A000100000002 /* SecurityManager.swift */,
 			);
 			path = Managers;
+			sourceTree = "<group>";
+		};
+		DFSP00042F50SPRITE004 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				DFSP00012F50SPRITE001 /* SpritePreviewManager.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 		DF675E612F2A46A1004CA019 /* Home */ = {
@@ -646,6 +658,7 @@
 				DFSEC0012F2A000100000001 /* SecurityManager.swift in Sources */,
 				DFSEC0032F2A000100000003 /* PasscodeEntryView.swift in Sources */,
 				DFSEC0052F2A000100000005 /* SecuritySettingsView.swift in Sources */,
+				DFSP00022F50SPRITE002 /* SpritePreviewManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -704,6 +717,7 @@
 				C047CE6380F048858A91E6C9 /* GraphQLClient.swift in Sources */,
 				C047CE6380F048858A91E6CA /* TrustAllSessionDelegate.swift in Sources */,
 				E909C6E8F4744C4D939F78BD /* GraphQLQueries.swift in Sources */,
+				DFSP00032F50SPRITE003 /* SpritePreviewManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/stashy/ReelsView.swift
+++ b/stashy/ReelsView.swift
@@ -1118,6 +1118,27 @@ struct ReelsView: View {
             }
         }
 
+        var videoAspectRatio: CGFloat? {
+            let file: SceneFile?
+            switch self {
+            case .scene(let s): file = s.files?.first
+            case .marker(let m): file = m.scene?.files?.first
+            case .preview(let s): file = s.files?.first
+            case .clip: file = nil
+            }
+            guard let w = file?.width, let h = file?.height, w > 0, h > 0 else { return nil }
+            return CGFloat(w) / CGFloat(h)
+        }
+
+        var spritePaths: (vtt: String?, sprite: String?) {
+            switch self {
+            case .scene(let s): return (s.paths?.vtt, s.paths?.sprite)
+            case .marker(let m): return (m.scene?.paths?.vtt, m.scene?.paths?.sprite)
+            case .preview(let s): return (s.paths?.vtt, s.paths?.sprite)
+            case .clip: return (nil, nil)
+            }
+        }
+
     }
 
     private var currentReelItems: [ReelItemData] {
@@ -3354,6 +3375,9 @@ struct ReelItemView: View {
     @State private var isFastForwarding = false
     var onInteraction: () -> Void
     @StateObject private var videoSurfaceReadiness = ReelItemVideoSurfaceReadiness()
+    @StateObject private var spritePreview = SpritePreviewManager()
+    @State private var isSwipeSeeking = false
+    @State private var seekTimeOffset: Double = 0
 
     private var shouldFill: Bool {
         // Only fill if the setting is enabled
@@ -3379,6 +3403,8 @@ struct ReelItemView: View {
     private var mainContent: some View {
         ZStack(alignment: .bottom) {
             mediaLayer
+            seekPreviewOverlay
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             fastForwardOverlay
             playButtonOverlay
             bottomBarOverlay
@@ -3572,7 +3598,7 @@ extension ReelItemView {
 
     @ViewBuilder
     private var mediaLayer: some View {
-        ZoomableScrollView(isZoomed: $isZoomed, onTap: handleMediaTap, onLongPress: handleLongPress) {
+        ZoomableScrollView(isZoomed: $isZoomed, onTap: handleMediaTap, onLongPress: handleLongPress, onHorizontalPan: handleSeekPan) {
             ZStack {
                 Group {
                     if item.isAnimated {
@@ -3664,6 +3690,103 @@ extension ReelItemView {
             }
         }
         onInteraction()
+    }
+
+    private func handleSeekPan(translation: CGFloat, state: UIGestureRecognizer.State) {
+        guard !item.isAnimated else { return }
+        let screenWidth = UIScreen.main.bounds.width
+        let deadzone: CGFloat = 20
+
+        switch state {
+        case .began, .changed:
+            let absTrans = abs(translation)
+            if absTrans < deadzone {
+                seekTimeOffset = 0
+                if isSwipeSeeking {
+                    withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = false }
+                }
+            } else {
+                let progress = min((absTrans - deadzone) / (screenWidth - deadzone), 1.0)
+                let seconds = 10.0 + Double(progress) * 1190.0
+                seekTimeOffset = translation > 0 ? seconds : -seconds
+                seekTimeOffset = max(-scrubberState.time, min(seekTimeOffset, scrubberState.duration - scrubberState.time))
+                if !isSwipeSeeking {
+                    withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = true }
+                }
+            }
+
+        case .ended:
+            if isSwipeSeeking && abs(seekTimeOffset) >= 10 {
+                let targetTime = max(0, min(scrubberState.time + seekTimeOffset, scrubberState.duration))
+                seek(to: targetTime)
+                onInteraction()
+            }
+            withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = false }
+            seekTimeOffset = 0
+
+        case .cancelled, .failed:
+            withAnimation(.easeOut(duration: 0.15)) { isSwipeSeeking = false }
+            seekTimeOffset = 0
+
+        default:
+            break
+        }
+    }
+
+    private func formatSeekOffset(_ seconds: Double) -> String {
+        let sign = seconds >= 0 ? "+" : "-"
+        let abs = abs(seconds)
+        let m = Int(abs) / 60
+        let s = Int(abs) % 60
+        return "\(sign)\(m):\(String(format: "%02d", s))"
+    }
+
+    private func formatTimestamp(_ seconds: Double) -> String {
+        let clamped = max(0, seconds)
+        let m = Int(clamped) / 60
+        let s = Int(clamped) % 60
+        return "\(m):\(String(format: "%02d", s))"
+    }
+
+    private var seekPreviewSize: CGSize {
+        let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+        let maxDim: CGFloat = isLandscape ? 120 : 140
+        let ratio = item.videoAspectRatio ?? 16.0 / 9.0
+        if ratio >= 1 {
+            return CGSize(width: maxDim, height: maxDim / ratio)
+        } else {
+            return CGSize(width: maxDim * ratio, height: maxDim)
+        }
+    }
+
+    @ViewBuilder
+    private var seekPreviewOverlay: some View {
+        if isSwipeSeeking {
+            let targetTime = max(0, min(scrubberState.time + seekTimeOffset, scrubberState.duration))
+            let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+            let previewSize = seekPreviewSize
+            VStack(alignment: .leading, spacing: 4) {
+                if let frame = spritePreview.frameImage(at: targetTime) {
+                    Image(uiImage: frame)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: previewSize.width, height: previewSize.height)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                Text(formatSeekOffset(seekTimeOffset))
+                    .font(.system(size: isLandscape ? 17 : 20, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white)
+                Text("→ \(formatTimestamp(targetTime))")
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .padding(10)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.top, isLandscape ? 16 : 80)
+            .padding(.leading, isLandscape ? 60 : 16)
+            .transition(.opacity)
+        }
     }
 
     @ViewBuilder
@@ -3811,6 +3934,9 @@ extension ReelItemView {
     func setupPlayer() {
         // Animations don't need AVPlayer
         guard !item.isAnimated else { return }
+
+        let paths = item.spritePaths
+        spritePreview.load(vttURLString: paths.vtt, spriteURLString: paths.sprite)
 
         // `onAppear` + scroll settle can both call `setupPlayer` in the same transition; avoid a second
         // `initPlayer`/generation bump (visible flash + duplicate stream work).

--- a/stashy/ReelsView.swift
+++ b/stashy/ReelsView.swift
@@ -3733,14 +3733,6 @@ extension ReelItemView {
         }
     }
 
-    private func formatSeekOffset(_ seconds: Double) -> String {
-        let sign = seconds >= 0 ? "+" : "-"
-        let abs = abs(seconds)
-        let m = Int(abs) / 60
-        let s = Int(abs) % 60
-        return "\(sign)\(m):\(String(format: "%02d", s))"
-    }
-
     private func formatTimestamp(_ seconds: Double) -> String {
         let clamped = max(0, seconds)
         let m = Int(clamped) / 60
@@ -3748,9 +3740,15 @@ extension ReelItemView {
         return "\(m):\(String(format: "%02d", s))"
     }
 
+    private var seekPreviewScale: CGFloat {
+        let shortEdge = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
+        return max(1.0, shortEdge / 390)
+    }
+
     private var seekPreviewSize: CGSize {
         let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
-        let maxDim: CGFloat = isLandscape ? 120 : 140
+        let scale = seekPreviewScale
+        let maxDim: CGFloat = (isLandscape ? 120 : 140) * scale
         let ratio = item.videoAspectRatio ?? 16.0 / 9.0
         if ratio >= 1 {
             return CGSize(width: maxDim, height: maxDim / ratio)
@@ -3764,26 +3762,25 @@ extension ReelItemView {
         if isSwipeSeeking {
             let targetTime = max(0, min(scrubberState.time + seekTimeOffset, scrubberState.duration))
             let isLandscape = UIScreen.main.bounds.width > UIScreen.main.bounds.height
+            let scale = seekPreviewScale
+            let textScale = sqrt(scale)
             let previewSize = seekPreviewSize
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 4 * textScale) {
                 if let frame = spritePreview.frameImage(at: targetTime) {
                     Image(uiImage: frame)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: previewSize.width, height: previewSize.height)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .clipShape(RoundedRectangle(cornerRadius: 8 * scale))
                 }
-                Text(formatSeekOffset(seekTimeOffset))
-                    .font(.system(size: isLandscape ? 17 : 20, weight: .bold, design: .monospaced))
+                Text(formatTimestamp(targetTime))
+                    .font(.system(size: (isLandscape ? 17 : 20) * textScale, weight: .bold, design: .monospaced))
                     .foregroundColor(.white)
-                Text("→ \(formatTimestamp(targetTime))")
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.7))
             }
-            .padding(10)
+            .padding(10 * textScale)
             .background(.ultraThinMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.top, isLandscape ? 16 : 80)
+            .clipShape(RoundedRectangle(cornerRadius: 12 * textScale))
+            .padding(.top, (isUIVisible ? (isLandscape ? 60 : 120) : (isLandscape ? 16 : 80)) * scale)
             .padding(.leading, isLandscape ? 60 : 16)
             .transition(.opacity)
         }

--- a/stashy/SharedUtilities.swift
+++ b/stashy/SharedUtilities.swift
@@ -402,16 +402,22 @@ struct AnimatedWebView: UIViewRepresentable {
 
 
 /// A wrapper around UIScrollView that provides pinch-to-zoom and panning for any SwiftUI view.
+class HorizontalSeekPanGesture: UIPanGestureRecognizer {
+    weak var scrollView: UIScrollView?
+}
+
 struct ZoomableScrollView<Content: View>: UIViewRepresentable {
     private var content: Content
     private var onTap: ((CGPoint) -> Void)?
     private var onLongPress: ((Bool) -> Void)?
+    private var onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)?
     @Binding var isZoomed: Bool
-    
-    init(isZoomed: Binding<Bool> = .constant(false), onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil, @ViewBuilder content: () -> Content) {
+
+    init(isZoomed: Binding<Bool> = .constant(false), onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil, onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)? = nil, @ViewBuilder content: () -> Content) {
         self._isZoomed = isZoomed
         self.onTap = onTap
         self.onLongPress = onLongPress
+        self.onHorizontalPan = onHorizontalPan
         self.content = content()
     }
     
@@ -455,32 +461,42 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
         let longPress = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
         longPress.minimumPressDuration = 0.3
         scrollView.addGestureRecognizer(longPress)
-        
+
+        #if !os(tvOS)
+        let seekPan = HorizontalSeekPanGesture(target: context.coordinator, action: #selector(Coordinator.handleSeekPan(_:)))
+        seekPan.scrollView = scrollView
+        seekPan.delegate = context.coordinator
+        scrollView.addGestureRecognizer(seekPan)
+        #endif
+
         return scrollView
     }
-    
+
     func updateUIView(_ uiView: UIScrollView, context: Context) {
         context.coordinator.hostingController.rootView = content
         context.coordinator.onTap = onTap
         context.coordinator.onLongPress = onLongPress
+        context.coordinator.onHorizontalPan = onHorizontalPan
         context.coordinator.isZoomed = $isZoomed
     }
-    
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(hostingController: UIHostingController(rootView: content), isZoomed: $isZoomed, onTap: onTap, onLongPress: onLongPress)
+        Coordinator(hostingController: UIHostingController(rootView: content), isZoomed: $isZoomed, onTap: onTap, onLongPress: onLongPress, onHorizontalPan: onHorizontalPan)
     }
     
-    class Coordinator: NSObject, UIScrollViewDelegate {
+    class Coordinator: NSObject, UIScrollViewDelegate, UIGestureRecognizerDelegate {
         var hostingController: UIHostingController<Content>
         var isZoomed: Binding<Bool>
         var onTap: ((CGPoint) -> Void)?
         var onLongPress: ((Bool) -> Void)?
-        
-        init(hostingController: UIHostingController<Content>, isZoomed: Binding<Bool>, onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil) {
+        var onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)?
+
+        init(hostingController: UIHostingController<Content>, isZoomed: Binding<Bool>, onTap: ((CGPoint) -> Void)? = nil, onLongPress: ((Bool) -> Void)? = nil, onHorizontalPan: ((CGFloat, UIGestureRecognizer.State) -> Void)? = nil) {
             self.hostingController = hostingController
             self.isZoomed = isZoomed
             self.onTap = onTap
             self.onLongPress = onLongPress
+            self.onHorizontalPan = onHorizontalPan
         }
         
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -517,6 +533,23 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
             }
         }
         
+        @objc func handleSeekPan(_ gesture: UIPanGestureRecognizer) {
+            let translation = gesture.translation(in: gesture.view)
+            onHorizontalPan?(translation.x, gesture.state)
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let seekPan = gestureRecognizer as? HorizontalSeekPanGesture else { return true }
+            guard let scrollView = seekPan.scrollView, scrollView.zoomScale <= 1.01 else { return false }
+            let vel = seekPan.velocity(in: seekPan.view)
+            return abs(vel.x) > abs(vel.y) * 1.5
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            if gestureRecognizer is HorizontalSeekPanGesture { return true }
+            return false
+        }
+
         @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
             guard let scrollView = gesture.view as? UIScrollView else { return }
             

--- a/stashy/Utilities/SpritePreviewManager.swift
+++ b/stashy/Utilities/SpritePreviewManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import UIKit
 
 struct VTTEntry {
@@ -16,12 +17,16 @@ class SpritePreviewManager: ObservableObject {
 
     private var vttEntries: [VTTEntry] = []
     private var loadTask: Task<Void, Never>?
+    private var cachedEntry: VTTEntry?
+    private var cachedFrame: UIImage?
 
     func load(vttURLString: String?, spriteURLString: String?) {
         loadTask?.cancel()
         vttEntries = []
         spriteImage = nil
         isLoaded = false
+        cachedEntry = nil
+        cachedFrame = nil
 
         guard let vttStr = vttURLString, let spriteStr = spriteURLString,
               let vttURL = URL(string: vttStr), let spriteURL = URL(string: spriteStr) else { return }
@@ -49,6 +54,12 @@ class SpritePreviewManager: ObservableObject {
         guard let sprite = spriteImage, let cgImage = sprite.cgImage else { return nil }
         guard let entry = findEntry(for: time) else { return nil }
 
+        if let cached = cachedEntry, cached.x == entry.x, cached.y == entry.y,
+           cached.width == entry.width, cached.height == entry.height,
+           let frame = cachedFrame {
+            return frame
+        }
+
         let scale = sprite.scale
         let cropRect = CGRect(
             x: CGFloat(entry.x) * scale,
@@ -57,7 +68,10 @@ class SpritePreviewManager: ObservableObject {
             height: CGFloat(entry.height) * scale
         )
         guard let cropped = cgImage.cropping(to: cropRect) else { return nil }
-        return UIImage(cgImage: cropped, scale: scale, orientation: .up)
+        let frame = UIImage(cgImage: cropped, scale: scale, orientation: .up)
+        cachedEntry = entry
+        cachedFrame = frame
+        return frame
     }
 
     private func findEntry(for time: Double) -> VTTEntry? {

--- a/stashy/Utilities/SpritePreviewManager.swift
+++ b/stashy/Utilities/SpritePreviewManager.swift
@@ -1,0 +1,175 @@
+import UIKit
+
+struct VTTEntry {
+    let startTime: Double
+    let endTime: Double
+    let x: Int
+    let y: Int
+    let width: Int
+    let height: Int
+}
+
+@MainActor
+class SpritePreviewManager: ObservableObject {
+    @Published var spriteImage: UIImage?
+    @Published var isLoaded = false
+
+    private var vttEntries: [VTTEntry] = []
+    private var loadTask: Task<Void, Never>?
+
+    func load(vttURLString: String?, spriteURLString: String?) {
+        loadTask?.cancel()
+        vttEntries = []
+        spriteImage = nil
+        isLoaded = false
+
+        guard let vttStr = vttURLString, let spriteStr = spriteURLString,
+              let vttURL = URL(string: vttStr), let spriteURL = URL(string: spriteStr) else { return }
+
+        let signedVTT = signedURL(vttURL) ?? vttURL
+        let signedSprite = signedURL(spriteURL) ?? spriteURL
+
+        loadTask = Task {
+            do {
+                let entries = try await fetchAndParseVTT(url: signedVTT)
+                if Task.isCancelled { return }
+                self.vttEntries = entries
+
+                let image = try await fetchSpriteImage(url: signedSprite)
+                if Task.isCancelled { return }
+                self.spriteImage = image
+                self.isLoaded = true
+            } catch {
+                // Non-blocking: sprite preview is optional
+            }
+        }
+    }
+
+    func frameImage(at time: Double) -> UIImage? {
+        guard let sprite = spriteImage, let cgImage = sprite.cgImage else { return nil }
+        guard let entry = findEntry(for: time) else { return nil }
+
+        let scale = sprite.scale
+        let cropRect = CGRect(
+            x: CGFloat(entry.x) * scale,
+            y: CGFloat(entry.y) * scale,
+            width: CGFloat(entry.width) * scale,
+            height: CGFloat(entry.height) * scale
+        )
+        guard let cropped = cgImage.cropping(to: cropRect) else { return nil }
+        return UIImage(cgImage: cropped, scale: scale, orientation: .up)
+    }
+
+    private func findEntry(for time: Double) -> VTTEntry? {
+        guard !vttEntries.isEmpty else { return nil }
+        var lo = 0
+        var hi = vttEntries.count - 1
+        while lo <= hi {
+            let mid = (lo + hi) / 2
+            let entry = vttEntries[mid]
+            if time < entry.startTime {
+                hi = mid - 1
+            } else if time >= entry.endTime {
+                lo = mid + 1
+            } else {
+                return entry
+            }
+        }
+        if let last = vttEntries.last, time >= last.startTime {
+            return last
+        }
+        return vttEntries.first
+    }
+
+    // MARK: - Network
+
+    private func fetchAndParseVTT(url: URL) async throws -> [VTTEntry] {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        if let config = ServerConfigManager.shared.activeConfig,
+           let apiKey = config.secureApiKey, !apiKey.isEmpty {
+            request.addValue(apiKey, forHTTPHeaderField: "ApiKey")
+        }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+        return parseVTT(text)
+    }
+
+    private func fetchSpriteImage(url: URL) async throws -> UIImage? {
+        if let cached = ImageCache.shared.object(forKey: url as NSURL) {
+            return cached
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        if let config = ServerConfigManager.shared.activeConfig,
+           let apiKey = config.secureApiKey, !apiKey.isEmpty {
+            request.addValue(apiKey, forHTTPHeaderField: "ApiKey")
+        }
+        let (data, _) = try await URLSession.shared.data(for: request)
+        guard let image = UIImage(data: data) else { return nil }
+        ImageCache.shared.setData(data, forKey: url as NSURL)
+        return image
+    }
+
+    // MARK: - VTT Parsing
+
+    private func parseVTT(_ text: String) -> [VTTEntry] {
+        var entries: [VTTEntry] = []
+        let lines = text.components(separatedBy: .newlines)
+        var i = 0
+
+        while i < lines.count {
+            let line = lines[i].trimmingCharacters(in: .whitespaces)
+            guard line.contains("-->") else { i += 1; continue }
+
+            let parts = line.components(separatedBy: "-->")
+            guard parts.count == 2 else { i += 1; continue }
+
+            let startTime = parseTimestamp(parts[0].trimmingCharacters(in: .whitespaces))
+            let endTime = parseTimestamp(parts[1].trimmingCharacters(in: .whitespaces))
+            guard let start = startTime, let end = endTime else { i += 1; continue }
+
+            i += 1
+            if i < lines.count {
+                let dataLine = lines[i].trimmingCharacters(in: .whitespaces)
+                if let entry = parseXYWH(dataLine, startTime: start, endTime: end) {
+                    entries.append(entry)
+                }
+            }
+            i += 1
+        }
+        return entries
+    }
+
+    private func parseTimestamp(_ str: String) -> Double? {
+        let components = str.components(separatedBy: ":")
+        guard components.count >= 2 else { return nil }
+
+        if components.count == 3 {
+            guard let h = Double(components[0]),
+                  let m = Double(components[1]),
+                  let s = Double(components[2]) else { return nil }
+            return h * 3600 + m * 60 + s
+        } else {
+            guard let m = Double(components[0]),
+                  let s = Double(components[1]) else { return nil }
+            return m * 60 + s
+        }
+    }
+
+    private func parseXYWH(_ line: String, startTime: Double, endTime: Double) -> VTTEntry? {
+        guard let hashIndex = line.firstIndex(of: "#") else { return nil }
+        let fragment = String(line[line.index(after: hashIndex)...])
+        guard fragment.hasPrefix("xywh=") else { return nil }
+
+        let values = fragment.dropFirst(5).components(separatedBy: ",")
+        guard values.count == 4,
+              let x = Int(values[0]),
+              let y = Int(values[1]),
+              let w = Int(values[2]),
+              let h = Int(values[3]) else { return nil }
+
+        return VTTEntry(startTime: startTime, endTime: endTime, x: x, y: y, width: w, height: h)
+    }
+}

--- a/stashyTV-Info.plist
+++ b/stashyTV-Info.plist
@@ -6,6 +6,14 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconName</key>
+			<string>AppIcon</string>
+		</dict>
+	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -18,6 +26,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -25,20 +35,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>CFBundleIcons</key>
-	<dict>
-		<key>CFBundlePrimaryIcon</key>
-		<dict>
-			<key>CFBundleIconName</key>
-			<string>AppIcon</string>
-		</dict>
-	</dict>
 	<key>TVTopShelfImage</key>
 	<dict>
 		<key>TVTopShelfPrimaryImageWide</key>
 		<string>TopShelfImageWide</string>
 	</dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 </dict>
 </plist>

--- a/stashyTV/TVApp.swift
+++ b/stashyTV/TVApp.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import CryptoKit
 import Combine
+import KSPlayer
 
 @main
 struct TVApp: App {
@@ -15,6 +16,11 @@ struct TVApp: App {
     @StateObject private var securityManager = TVSecurityManager.shared
     @Environment(\.scenePhase) private var scenePhase
     @State private var lastScenePhase: ScenePhase = .active
+
+    init() {
+        KSOptions.firstPlayerType = KSMEPlayer.self
+        KSOptions.secondPlayerType = KSAVPlayer.self
+    }
 
     var body: some SwiftUI.Scene {
         WindowGroup {

--- a/stashyTV/TVOCountPill.swift
+++ b/stashyTV/TVOCountPill.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct TVOCountPill: View {
+    let oCounter: Int?
+    let iconName: String
+    let onIncrement: () -> Void
+
+    @State private var isFocused = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: iconName)
+                .foregroundColor(.red)
+            Text("\(oCounter ?? 0)")
+        }
+        .font(.headline)
+        .foregroundColor(.white.opacity(0.7))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(isFocused ? Color.white.opacity(0.15) : Color.white.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .scaleEffect(isFocused ? 1.05 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        .overlay {
+            OCountFocusInputView(
+                isFocused: $isFocused,
+                onSelect: onIncrement
+            )
+        }
+    }
+}
+
+// MARK: - UIKit focus view for reliable focus detection
+
+private struct OCountFocusInputView: UIViewRepresentable {
+    @Binding var isFocused: Bool
+    var onSelect: () -> Void
+
+    func makeUIView(context: Context) -> OCountFocusUIView {
+        let view = OCountFocusUIView()
+        view.backgroundColor = .clear
+        view.onSelect = onSelect
+        view.onFocusChange = { focused in
+            DispatchQueue.main.async { isFocused = focused }
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: OCountFocusUIView, context: Context) {
+        uiView.onSelect = onSelect
+    }
+}
+
+private final class OCountFocusUIView: UIView {
+    var onSelect: (() -> Void)?
+    var onFocusChange: ((Bool) -> Void)?
+
+    override var canBecomeFocused: Bool { true }
+
+    override func didUpdateFocus(
+        in context: UIFocusUpdateContext,
+        with coordinator: UIFocusAnimationCoordinator
+    ) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        onFocusChange?(isFocused)
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        guard let press = presses.first else {
+            super.pressesBegan(presses, with: event)
+            return
+        }
+        switch press.type {
+        case .select:
+            onSelect?()
+        default:
+            super.pressesBegan(presses, with: event)
+        }
+    }
+}

--- a/stashyTV/TVSceneCardView.swift
+++ b/stashyTV/TVSceneCardView.swift
@@ -6,12 +6,19 @@
 //
 
 import SwiftUI
+import AVKit
 
 struct TVSceneCardView: View {
     let scene: Scene
     var width: CGFloat = 410
     var height: CGFloat = 230
     @Environment(\.isFocused) var isFocused
+
+    // Hover-to-preview state
+    @State private var previewPlayer: AVPlayer?
+    @State private var showPreview = false
+    @State private var hoverTask: Task<Void, Never>?
+    @State private var loopObserver: NSObjectProtocol?
 
     var body: some View {
         // Thumbnail with overlays
@@ -21,6 +28,15 @@ struct TVSceneCardView: View {
                 .frame(width: width, height: height)
                 .clipped()
                 .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            // Video preview overlay (shown after hovering ~1s)
+            if showPreview, let previewPlayer {
+                TVPreviewPlayerView(player: previewPlayer)
+                    .frame(width: width, height: height)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+            }
 
             // Gradient
             LinearGradient(
@@ -109,6 +125,76 @@ struct TVSceneCardView: View {
             }
         }
         .frame(width: width, height: height)
+        .onChange(of: isFocused) { focused in
+            if focused {
+                startHoverPreview()
+            } else {
+                teardownPreview()
+            }
+        }
+        .onDisappear {
+            teardownPreview()
+        }
+    }
+
+    // MARK: - Hover preview
+
+    private func startHoverPreview() {
+        hoverTask?.cancel()
+        guard let previewURL = scene.previewURL else { return }
+        hoverTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard !Task.isCancelled else { return }
+
+            let player = createMutedPreviewPlayer(for: previewURL)
+            player.actionAtItemEnd = .none
+            loopObserver = NotificationCenter.default.addObserver(
+                forName: .AVPlayerItemDidPlayToEndTime,
+                object: player.currentItem,
+                queue: .main
+            ) { _ in
+                player.seek(to: .zero)
+                player.play()
+            }
+            previewPlayer = player
+            player.play()
+            withAnimation(.easeIn(duration: 0.25)) {
+                showPreview = true
+            }
+        }
+    }
+
+    private func teardownPreview() {
+        hoverTask?.cancel()
+        hoverTask = nil
+
+        // Stop playback and detach the loop observer immediately so audio,
+        // network, and the seek-to-start loop halt the moment focus leaves.
+        if let loopObserver {
+            NotificationCenter.default.removeObserver(loopObserver)
+            self.loopObserver = nil
+        }
+        let departingPlayer = previewPlayer
+        departingPlayer?.pause()
+
+        guard showPreview else {
+            // Nothing on screen yet (e.g. torn down before the 1s timer fired).
+            previewPlayer = nil
+            return
+        }
+
+        // Keep the player attached through the fade so .transition(.opacity)
+        // can cross-fade back to the thumbnail, then release it once done.
+        withAnimation(.easeOut(duration: 0.2)) {
+            showPreview = false
+        }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            // Skip if a new preview took over during the fade-out.
+            if previewPlayer === departingPlayer {
+                previewPlayer = nil
+            }
+        }
     }
 
     // MARK: - Thumbnail
@@ -164,8 +250,45 @@ struct TVSceneCardView: View {
 
 struct TVSceneCardTitleView: View {
     let scene: Scene
-    
+
     var body: some View {
         EmptyView()
+    }
+}
+
+// Lightweight AVPlayerLayer-backed view for muted hover previews on tvOS.
+struct TVPreviewPlayerView: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> PlayerLayerView {
+        PlayerLayerView(player: player)
+    }
+
+    func updateUIView(_ uiView: PlayerLayerView, context: Context) {
+        if uiView.player !== player {
+            uiView.player = player
+        }
+    }
+
+    final class PlayerLayerView: UIView {
+        override class var layerClass: AnyClass { AVPlayerLayer.self }
+
+        private var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
+
+        var player: AVPlayer? {
+            get { playerLayer.player }
+            set { playerLayer.player = newValue }
+        }
+
+        init(player: AVPlayer) {
+            super.init(frame: .zero)
+            self.player = player
+            playerLayer.videoGravity = .resizeAspectFill
+            isUserInteractionEnabled = false
+        }
+
+        required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+        override var canBecomeFocused: Bool { false }
     }
 }

--- a/stashyTV/TVSceneDetailView.swift
+++ b/stashyTV/TVSceneDetailView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import AVKit
 import Combine
+import KSPlayer
 
 struct TVSceneDetailView: View {
     let sceneId: String
@@ -20,6 +21,8 @@ struct TVSceneDetailView: View {
     @State private var isLoadingDetail = true
     @State private var isLoadingStreams = true
     @State private var hasAddedPlay = false
+    @Namespace private var focusNS
+    @Environment(\.resetFocus) private var resetFocus
 
     /// Same idea as iOS `ScenesView`: list/detail only treat transport/config as “connection” errors.
     private var hasValidActiveServer: Bool {
@@ -107,20 +110,30 @@ struct TVSceneDetailView: View {
         }
         .onPlayPauseCommand {
             if sceneDetail != nil {
-                if playerViewModel.player?.rate == 0 {
-                    playerViewModel.player?.play()
-                } else {
-                    playerViewModel.player?.pause()
+                if let playerLayer = playerViewModel.ksCoordinator.playerLayer {
+                    if playerLayer.player.isPlaying {
+                        playerLayer.pause()
+                    } else {
+                        playerLayer.play()
+                    }
                 }
             }
         }
+        .focusScope(focusNS)
         .fullScreenCover(isPresented: $playerViewModel.isShowingPlayer, onDismiss: {
             playerViewModel.clear()
-            loadData()
-        }) {
-            if let player = playerViewModel.player {
-                TVVideoPlayerView(player: player, isPresented: $playerViewModel.isShowingPlayer)
+            loadData(silent: true)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                resetFocus(in: focusNS)
             }
+        }) {
+            TVVideoPlayerView(
+                playerViewModel: playerViewModel,
+                isPresented: $playerViewModel.isShowingPlayer,
+                sceneTitle: sceneDetail?.title,
+                vttURLString: sceneDetail?.paths?.vtt,
+                spriteURLString: sceneDetail?.paths?.sprite
+            )
         }
     }
 
@@ -151,24 +164,30 @@ struct TVSceneDetailView: View {
         loadData()
     }
 
-    private func loadData() {
+    private func loadData(silent: Bool = false) {
         guard hasValidActiveServer else {
-            isLoadingDetail = false
-            isLoadingStreams = false
+            if !silent {
+                isLoadingDetail = false
+                isLoadingStreams = false
+            }
             return
         }
 
-        isLoadingDetail = true
-        isLoadingStreams = true
+        if !silent {
+            isLoadingDetail = true
+            isLoadingStreams = true
+        }
 
         viewModel.fetchSceneDetails(sceneId: sceneId) { scene in
             self.sceneDetail = scene
-            self.isLoadingDetail = false
+            if !silent { self.isLoadingDetail = false }
         }
 
-        viewModel.fetchSceneStreams(sceneId: sceneId) { streams in
-            self.sceneStreams = streams
-            self.isLoadingStreams = false
+        if !silent {
+            viewModel.fetchSceneStreams(sceneId: sceneId) { streams in
+                self.sceneStreams = streams
+                self.isLoadingStreams = false
+            }
         }
     }
 
@@ -332,6 +351,7 @@ struct TVSceneDetailView: View {
                     .padding(.vertical, 8)
                 }
                 .disabled(!hasStream || (isWaiting && !hasStream))
+                .prefersDefaultFocus(in: focusNS)
 
                 // Restart Action
                 if hasProgress {
@@ -444,42 +464,15 @@ struct TVSceneDetailView: View {
         }
         
         let quality = ServerConfigManager.shared.activeConfig?.defaultQuality ?? .original
-        let compatible = ["mp4", "m4v", "mov"]
-        let fileFormat = scene.files?.first?.format?.lowercased() ?? ""
-        let isNativelyCompatible = compatible.contains(fileFormat)
-        
-        // Use bestStream() which respects quality settings and format compatibility.
-        // For compatible formats (MP4) at Original quality, bestStream returns nil
-        // → use direct stream path (much faster seeking than HLS transcoding).
+
+        // KSPlayer handles all container formats (MKV, AVI, etc.) natively via FFmpeg,
+        // so no format-gating is needed. Just respect the user's quality preference.
         let sceneWithStreams = scene.withStreams(sceneStreams)
         if let streamURL = sceneWithStreams.bestStream(for: quality) {
-            print("📺 TV: Using quality-selected stream (\(quality.displayName)) for format: \(fileFormat)")
             playerViewModel.setupPlayer(url: streamURL, sceneId: scene.id, viewModel: viewModel, startAt: startTime)
             return
         }
-        
-        // Non-compatible format (MKV, AVI, WMV, etc.): force HLS even if bestStream
-        // returned nil (e.g. because sceneStreams were not loaded).
-        // Apple TV cannot play these formats via direct stream.
-        if !isNativelyCompatible {
-            // Try any available HLS stream first
-            if let hlsStream = sceneStreams.first(where: { $0.mime_type == "application/vnd.apple.mpegurl" }),
-               let url = URL(string: hlsStream.url) {
-                print("📺 TV: Non-MP4 (\(fileFormat)) — forcing HLS stream")
-                playerViewModel.setupPlayer(url: url, sceneId: scene.id, viewModel: viewModel, startAt: startTime)
-                return
-            }
-            // Try MP4 transcode stream as fallback
-            if let mp4Stream = sceneStreams.first(where: { $0.mime_type == "video/mp4" }),
-               let url = URL(string: mp4Stream.url) {
-                print("📺 TV: Non-MP4 (\(fileFormat)) — using MP4 transcode stream")
-                playerViewModel.setupPlayer(url: url, sceneId: scene.id, viewModel: viewModel, startAt: startTime)
-                return
-            }
-        }
-        
-        // Direct stream fallback — only safe for natively compatible formats (MP4/MOV/M4V)
-        // or when format is unknown (Stash transcodes on the fly via /stream endpoint)
+
         if let directPath = scene.paths?.stream {
             let fullURL: String
             if directPath.starts(with: "http://") || directPath.starts(with: "https://") {
@@ -490,7 +483,6 @@ struct TVSceneDetailView: View {
                 return
             }
             if let url = URL(string: fullURL) {
-                print("📺 TV: Using direct stream for \(isNativelyCompatible ? "compatible" : "unknown") format (\(fileFormat))")
                 playerViewModel.setupPlayer(url: url, sceneId: scene.id, viewModel: viewModel, startAt: startTime)
             }
         }
@@ -733,148 +725,494 @@ struct TVSceneDetailView: View {
 // MARK: - Player View Model
 
 class TVPlayerViewModel: ObservableObject {
-    @Published var player: AVPlayer?
+    @Published var playbackURL: URL?
+    @Published var startSeconds: Double = 0
     @Published var isShowingPlayer = false
     @Published var error: Error?
 
-    private var statusObserver: NSKeyValueObservation?
+    let ksCoordinator = KSVideoPlayer.Coordinator()
     private var progressTimer: AnyCancellable?
-    /// Nach System-Spulen bleibt der Player oft bei rate 0; Apple-TV+-ähnlich wieder anspielen.
-    private var timeJumpedObserver: NSObjectProtocol?
     private var sceneId: String?
     private var viewModel: StashDBViewModel?
-    /// Avoid duplicate seek/play when `status` KVO fires more than once at `.readyToPlay`.
-    private var didApplyInitialPlayback = false
 
     func setupPlayer(url: URL, sceneId: String, viewModel: StashDBViewModel, startAt timestamp: Double = 0) {
-        print("🚀 TV PLAYER VM: Setting up player for URL: \(url.absoluteString) at \(timestamp)s")
+        let authenticatedURL = signedURL(url) ?? url
         self.sceneId = sceneId
         self.viewModel = viewModel
-        self.didApplyInitialPlayback = false
-
-        let newPlayer = createPlayer(for: url)
-        self.player = newPlayer
+        self.startSeconds = max(0, timestamp)
+        self.playbackURL = authenticatedURL
         self.isShowingPlayer = true
-
-        let startSeconds = max(0, timestamp)
-
-        statusObserver = newPlayer.currentItem?.observe(\.status, options: [.new, .initial]) { [weak self, weak newPlayer] item, _ in
-            guard let self, let newPlayer else { return }
-            DispatchQueue.main.async {
-                guard self.player === newPlayer else { return }
-                if item.status == .failed {
-                    self.error = item.error
-                    print("❌ TV PLAYER VM: Playback FAILED: \(item.error?.localizedDescription ?? "Unknown error")")
-                    if let error = item.error as NSError? {
-                        print("❌ TV PLAYER VM: Error domain: \(error.domain), code: \(error.code)")
-                        print("❌ TV PLAYER VM: Error user info: \(error.userInfo)")
-                    }
-                } else if item.status == .readyToPlay {
-                    print("✅ TV PLAYER VM: Player item READY to play")
-                    self.applyInitialPlaybackIfNeeded(player: newPlayer, startSeconds: startSeconds)
-                }
-            }
-        }
 
         progressTimer = Timer.publish(every: 10, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 self?.saveProgress()
             }
-
-        registerAutoResumeAfterScrub(on: newPlayer)
-    }
-
-    private func registerAutoResumeAfterScrub(on player: AVPlayer) {
-        removeTimeJumpedObserver()
-        guard let item = player.currentItem else { return }
-        timeJumpedObserver = NotificationCenter.default.addObserver(
-            forName: .AVPlayerItemTimeJumped,
-            object: item,
-            queue: .main
-        ) { [weak player] _ in
-            guard let player, player.rate == 0 else { return }
-            player.play()
-        }
-    }
-
-    private func removeTimeJumpedObserver() {
-        if let token = timeJumpedObserver {
-            NotificationCenter.default.removeObserver(token)
-            timeJumpedObserver = nil
-        }
-    }
-
-    /// Seeking before `readyToPlay` (especially HLS/transcodes) causes UI hangs and endless buffering after scrubs.
-    private func applyInitialPlaybackIfNeeded(player: AVPlayer, startSeconds: Double) {
-        guard !didApplyInitialPlayback else { return }
-        didApplyInitialPlayback = true
-
-        let item = player.currentItem
-        let durationSec = item?.duration.seconds ?? 0
-        var start = startSeconds
-        if durationSec.isFinite, durationSec > 0 {
-            start = min(start, max(0, durationSec - 0.5))
-        }
-
-        if start > 0.25 {
-            let target = CMTime(seconds: start, preferredTimescale: 600)
-            let tol = CMTime(seconds: 2, preferredTimescale: 600)
-            player.seek(to: target, toleranceBefore: tol, toleranceAfter: tol) { [weak self, weak player] _ in
-                DispatchQueue.main.async {
-                    guard let self, let player, self.player === player else { return }
-                    player.play()
-                }
-            }
-        } else {
-            player.play()
-        }
     }
 
     func saveProgress() {
-        guard let player = player,
-              let sceneId = sceneId,
-              let viewModel = viewModel else { return }
-        
-        let currentTime = player.currentTime().seconds
+        guard let sceneId, let viewModel else { return }
+        let currentTime = ksCoordinator.playerLayer?.player.currentPlaybackTime ?? 0
         if currentTime > 0 {
-            print("💾 TV PLAYER VM: Saving progress: \(currentTime)s for \(sceneId)")
             viewModel.updateSceneResumeTime(sceneId: sceneId, resumeTime: currentTime)
         }
     }
 
     func clear() {
         saveProgress()
-        removeTimeJumpedObserver()
         progressTimer = nil
-        statusObserver = nil
-        didApplyInitialPlayback = true
-        let p = player
-        player = nil
+        ksCoordinator.resetPlayer()
+        playbackURL = nil
         sceneId = nil
         viewModel = nil
-        p?.pause()
-        p?.replaceCurrentItem(with: nil)
     }
 }
 
 // MARK: - Embedded Video Player for tvOS Full Screen Cover
 
 struct TVVideoPlayerView: View {
-    let player: AVPlayer
+    @ObservedObject var playerViewModel: TVPlayerViewModel
+    @ObservedObject private var timeModel: ControllerTimeModel
     @Binding var isPresented: Bool
+    var sceneTitle: String?
+    var vttURLString: String?
+    var spriteURLString: String?
+
+    init(playerViewModel: TVPlayerViewModel, isPresented: Binding<Bool>, sceneTitle: String? = nil, vttURLString: String? = nil, spriteURLString: String? = nil) {
+        self.playerViewModel = playerViewModel
+        self._timeModel = ObservedObject(wrappedValue: playerViewModel.ksCoordinator.timemodel)
+        self._isPresented = isPresented
+        self.sceneTitle = sceneTitle
+        self.vttURLString = vttURLString
+        self.spriteURLString = spriteURLString
+    }
+
+    @State private var showControls = true
+    @State private var hideTask: Task<Void, Never>?
+    @State private var isScrubbing = false
+    @State private var seekTargetTime: Double = 0
+    @State private var panAnchorTime: Double = 0
+    @StateObject private var spritePreview = SpritePreviewManager()
+
+    private var coordinator: KSVideoPlayer.Coordinator { playerViewModel.ksCoordinator }
+    private var isPlaying: Bool {
+        let s = coordinator.state
+        return s == .buffering || s == .bufferFinished
+    }
+    private var currentPlaybackTime: Double {
+        coordinator.playerLayer?.player.currentPlaybackTime ?? Double(timeModel.currentTime)
+    }
 
     var body: some View {
-        VideoPlayer(player: player) {
-            // Empty overlay - VideoPlayer provides native tvOS controls
+        if let url = playerViewModel.playbackURL {
+            ZStack {
+                KSVideoPlayer(coordinator: coordinator, url: url, options: tvKSOptions())
+                    .onStateChanged { playerLayer, state in
+                        if state == .readyToPlay, playerViewModel.startSeconds > 0.25 {
+                            let seekTo = playerViewModel.startSeconds
+                            playerViewModel.startSeconds = 0
+                            playerLayer.seek(time: seekTo, autoPlay: true) { _ in }
+                        }
+                        if state == .bufferFinished {
+                            scheduleHide()
+                        }
+                    }
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+
+                TVRemoteInputView(
+                    onSelect: { handleSelectOrPlayPause() },
+                    onPlayPause: { handleSelectOrPlayPause() },
+                    onLeft: { handleHorizontal(scrubDelta: -20, skipInterval: -20) },
+                    onRight: { handleHorizontal(scrubDelta: 20, skipInterval: 20) },
+                    onUp: {
+                        if isPlaying {
+                            coordinator.skip(interval: 180)
+                            flashControls()
+                        }
+                    },
+                    onDown: {
+                        if isPlaying {
+                            coordinator.skip(interval: -180)
+                            flashControls()
+                        }
+                    },
+                    onMenu: {
+                        if isScrubbing {
+                            cancelScrub()
+                        } else if showControls {
+                            showControls = false
+                        } else {
+                            isPresented = false
+                        }
+                    },
+                    onPan: { translation, state in
+                        handleScrubPan(translation: translation, state: state)
+                    }
+                )
+
+                if showControls {
+                    transportOverlay
+                        .transition(.opacity)
+                        .allowsHitTesting(false)
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: showControls)
+            .animation(.easeInOut(duration: 0.2), value: isScrubbing)
+            .onAppear {
+                spritePreview.load(vttURLString: vttURLString, spriteURLString: spriteURLString)
+            }
+            .onDisappear {
+                hideTask?.cancel()
+            }
         }
-        .ignoresSafeArea()
-        .onExitCommand {
-            // Menu button should close the player, not exit the app.
-            isPresented = false
+    }
+
+    // MARK: - Transport Overlay
+
+    @ViewBuilder
+    private var transportOverlay: some View {
+        let currentActual = Double(timeModel.currentTime)
+        let total = Double(max(timeModel.totalTime, 1))
+        let displayTime = isScrubbing ? seekTargetTime : currentActual
+        let fraction = min(max(displayTime / total, 0), 1)
+
+        ZStack(alignment: .bottom) {
+            LinearGradient(
+                colors: [.clear, .black.opacity(0.7)],
+                startPoint: .init(x: 0.5, y: 0.5),
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 12) {
+                if let title = sceneTitle, !title.isEmpty {
+                    Text(title)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.white)
+                }
+
+                GeometryReader { geo in
+                    let barHeight: CGFloat = 8
+                    let playedWidth = geo.size.width * fraction
+
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(.white.opacity(0.15))
+                            .overlay { Capsule().fill(.ultraThinMaterial) }
+                            .environment(\.colorScheme, .dark)
+                            .frame(height: barHeight)
+
+                        if isScrubbing {
+                            let currentFraction = min(max(currentActual / total, 0), 1)
+                            Capsule()
+                                .fill(Color.white.opacity(0.4))
+                                .frame(width: max(geo.size.width * currentFraction, barHeight), height: barHeight)
+                        }
+
+                        Capsule()
+                            .fill(Color.white)
+                            .shadow(color: .white.opacity(0.5), radius: 4, x: 0, y: 0)
+                            .frame(width: max(playedWidth, barHeight), height: barHeight)
+                            .animation(.easeOut(duration: 0.3), value: playedWidth)
+                    }
+                    .overlay(alignment: .bottom) {
+                        if isScrubbing {
+                            spriteSeekPreview(seekTime: seekTargetTime, barWidth: geo.size.width, fraction: fraction)
+                                .offset(y: -20)
+                        }
+                    }
+                }
+                .frame(height: 8)
+
+                HStack(spacing: 8) {
+                    Text(formatTime(displayTime))
+                        .monospacedDigit()
+                    Image(systemName: isPlaying ? "play.circle.fill" : "pause.circle.fill")
+                        .font(.callout)
+
+                    Spacer()
+
+                    Text("-\(formatTime(max(0, total - displayTime)))")
+                        .monospacedDigit()
+                }
+                .font(.callout)
+                .foregroundStyle(.white)
+            }
+            .padding(.horizontal, 80)
+            .padding(.bottom, 60)
         }
-        .onDisappear {
-            // Final progress save handled by VM clear
+    }
+
+    // MARK: - Sprite Seek Preview
+
+    @ViewBuilder
+    private func spriteSeekPreview(seekTime: Double, barWidth: CGFloat, fraction: Double) -> some View {
+        let thumbWidth: CGFloat = 280
+        let thumbHeight: CGFloat = 158
+        let halfThumb = thumbWidth / 2
+        let centerX = barWidth * fraction
+        let clampedX = min(max(centerX, halfThumb), barWidth - halfThumb)
+
+        VStack(spacing: 6) {
+            if let frame = spritePreview.frameImage(at: seekTime) {
+                Image(uiImage: frame)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: thumbWidth, height: thumbHeight)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(Color.white.opacity(0.3), lineWidth: 1)
+                    )
+                    .shadow(color: .black.opacity(0.6), radius: 8, x: 0, y: 4)
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(.ultraThinMaterial)
+                    .environment(\.colorScheme, .dark)
+                    .frame(width: thumbWidth, height: thumbHeight)
+                    .overlay(
+                        Text(formatTime(seekTime))
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                    )
+            }
         }
+        .fixedSize()
+        .position(x: clampedX, y: -(thumbHeight / 2))
+    }
+
+    // MARK: - Scrubbing
+
+    private func handleSelectOrPlayPause() {
+        if isScrubbing {
+            commitScrub()
+        } else {
+            togglePlayPause()
+            flashControls()
+        }
+    }
+
+    private func handleHorizontal(scrubDelta: Double, skipInterval: Int) {
+        if !isPlaying {
+            enterOrContinueScrub(delta: scrubDelta)
+        } else {
+            coordinator.skip(interval: skipInterval)
+            flashControls()
+        }
+    }
+
+    private func enterOrContinueScrub(delta: Double) {
+        let total = Double(timeModel.totalTime)
+        guard total > 0 else { return }
+
+        let base = isScrubbing ? seekTargetTime : currentPlaybackTime
+        seekTargetTime = max(0, min(base + delta, total))
+        if !isScrubbing { isScrubbing = true }
+        showControls = true
+        hideTask?.cancel()
+    }
+
+    private func commitScrub() {
+        guard isScrubbing, let layer = coordinator.playerLayer else { return }
+        isScrubbing = false
+        layer.seek(time: seekTargetTime, autoPlay: true) { _ in }
+        flashControls()
+    }
+
+    private func cancelScrub() {
+        isScrubbing = false
+        flashControls()
+    }
+
+    private func handleScrubPan(translation: CGFloat, state: UIGestureRecognizer.State) {
+        guard !isPlaying else { return }
+        let total = Double(timeModel.totalTime)
+        guard total > 0 else { return }
+
+        switch state {
+        case .began:
+            panAnchorTime = isScrubbing ? seekTargetTime : currentPlaybackTime
+            if !isScrubbing { isScrubbing = true }
+            showControls = true
+            hideTask?.cancel()
+        case .changed:
+            let offset = Double(translation / 1600) * total
+            seekTargetTime = max(0, min(panAnchorTime + offset, total))
+        default:
+            break
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func togglePlayPause() {
+        if let layer = coordinator.playerLayer {
+            if isPlaying {
+                layer.pause()
+            } else {
+                layer.play()
+            }
+        }
+    }
+
+    private func flashControls() {
+        showControls = true
+        scheduleHide()
+    }
+
+    private func scheduleHide() {
+        hideTask?.cancel()
+        hideTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(4))
+            guard !Task.isCancelled else { return }
+            if isPlaying && !isScrubbing {
+                showControls = false
+            }
+        }
+    }
+
+    private func formatTime(_ seconds: Double) -> String {
+        let s = Int(max(0, seconds))
+        let h = s / 3600
+        let m = (s % 3600) / 60
+        let sec = s % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, sec)
+        }
+        return String(format: "%d:%02d", m, sec)
+    }
+
+    private func tvKSOptions() -> KSOptions {
+        let o = KSOptions()
+        o.preferredForwardBufferDuration = 2
+        if let key = ServerConfigManager.shared.activeConfig?.secureApiKey, !key.isEmpty {
+            o.appendHeader(["ApiKey": key])
+        }
+        return o
+    }
+}
+
+// MARK: - Focus-owning UIKit view for Siri Remote input
+
+struct TVRemoteInputView: UIViewRepresentable {
+    var onSelect: () -> Void
+    var onPlayPause: () -> Void
+    var onLeft: () -> Void
+    var onRight: () -> Void
+    var onUp: () -> Void
+    var onDown: () -> Void
+    var onMenu: () -> Void
+    var onPan: ((CGFloat, UIGestureRecognizer.State) -> Void)?
+
+    func makeUIView(context: Context) -> TVRemoteInputUIView {
+        let view = TVRemoteInputUIView()
+        view.onSelect = onSelect
+        view.onPlayPause = onPlayPause
+        view.onLeft = onLeft
+        view.onRight = onRight
+        view.onUp = onUp
+        view.onDown = onDown
+        view.onMenu = onMenu
+        view.onPan = onPan
+        return view
+    }
+
+    func updateUIView(_ uiView: TVRemoteInputUIView, context: Context) {
+        uiView.onSelect = onSelect
+        uiView.onPlayPause = onPlayPause
+        uiView.onLeft = onLeft
+        uiView.onRight = onRight
+        uiView.onUp = onUp
+        uiView.onDown = onDown
+        uiView.onMenu = onMenu
+        uiView.onPan = onPan
+    }
+}
+
+final class TVRemoteInputUIView: UIView {
+    var onSelect: (() -> Void)?
+    var onPlayPause: (() -> Void)?
+    var onLeft: (() -> Void)?
+    var onRight: (() -> Void)?
+    var onUp: (() -> Void)?
+    var onDown: (() -> Void)?
+    var onMenu: (() -> Void)?
+    var onPan: ((CGFloat, UIGestureRecognizer.State) -> Void)?
+
+    private var repeatTimer: Timer?
+    private var panRecognizer: UIPanGestureRecognizer?
+
+    override var canBecomeFocused: Bool { true }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            setNeedsFocusUpdate()
+            updateFocusIfNeeded()
+            if panRecognizer == nil {
+                let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+                addGestureRecognizer(pan)
+                panRecognizer = pan
+            }
+        }
+    }
+
+    @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {
+        let translation = recognizer.translation(in: self).x
+        onPan?(translation, recognizer.state)
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        guard let press = presses.first else {
+            super.pressesBegan(presses, with: event)
+            return
+        }
+        switch press.type {
+        case .select:
+            onSelect?()
+        case .playPause:
+            onPlayPause?()
+        case .leftArrow:
+            onLeft?()
+            startRepeat { [weak self] in self?.onLeft?() }
+        case .rightArrow:
+            onRight?()
+            startRepeat { [weak self] in self?.onRight?() }
+        case .upArrow:
+            onUp?()
+            startRepeat { [weak self] in self?.onUp?() }
+        case .downArrow:
+            onDown?()
+            startRepeat { [weak self] in self?.onDown?() }
+        case .menu:
+            onMenu?()
+        default:
+            super.pressesBegan(presses, with: event)
+        }
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        stopRepeat()
+        super.pressesEnded(presses, with: event)
+    }
+
+    override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        stopRepeat()
+        super.pressesCancelled(presses, with: event)
+    }
+
+    private func startRepeat(_ action: @escaping () -> Void) {
+        stopRepeat()
+        repeatTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { _ in
+            action()
+        }
+    }
+
+    private func stopRepeat() {
+        repeatTimer?.invalidate()
+        repeatTimer = nil
     }
 }

--- a/stashyTV/TVSceneDetailView.swift
+++ b/stashyTV/TVSceneDetailView.swift
@@ -268,68 +268,7 @@ struct TVSceneDetailView: View {
                     .frame(maxWidth: 1000, alignment: .leading)
             }
 
-            // 4. Metadata Line (Duration, Res) + Progress Bar
-            HStack(spacing: 24) {
-                if let duration = scene.sceneDuration, duration > 0 {
-                    HStack(spacing: 6) {
-                        Image(systemName: "clock")
-                        Text(formattedDuration(duration))
-                    }
-                    .font(.headline)
-                }
-
-                if let resolution = resolutionString(for: scene) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "tv")
-                        Text(resolution)
-                    }
-                    .font(.headline)
-                }
-
-                // Rating Pill
-                if let rating100 = scene.rating100, rating100 > 0 {
-                    HStack(spacing: 8) {
-                        Image(systemName: "star.fill")
-                            .foregroundColor(.yellow)
-                        Text(String(format: "%.1f", Double(rating100) / 20.0))
-                    }
-                    .font(.headline)
-                }
-
-                // O-Count Pill
-                if let oCounter = scene.oCounter, oCounter > 0 {
-                    HStack(spacing: 6) {
-                        Image(systemName: "heart.circle")
-                        Text("\(oCounter)")
-                    }
-                    .font(.headline)
-                }
-                
-                // Progress Bar inline with metadata
-                if let resumeTime = scene.resumeTime, resumeTime > 0, let duration = scene.sceneDuration, duration > 0 {
-                    HStack(spacing: 12) {
-                        Image(systemName: "play.fill")
-                            .font(.caption)
-                        
-                        Text("\(Int(resumeTime / duration * 100))%")
-                            .font(.headline)
-                        
-                        GeometryReader { geo in
-                            ZStack(alignment: .leading) {
-                                Rectangle().fill(Color.white.opacity(0.3))
-                                Rectangle().fill(AppearanceManager.shared.tintColor)
-                                    .frame(width: geo.size.width * CGFloat(resumeTime / duration))
-                            }
-                        }
-                        .frame(width: 200, height: 4)
-                        .clipShape(Capsule())
-                    }
-                }
-            }
-            .foregroundColor(.white.opacity(0.9))
-            .padding(.top, 8)
-
-            // 5. Action Buttons & Info Pills Row
+            // 4. Action Buttons & Info Pills Row
             HStack(spacing: 20) {
                 // Play Action
                 Button {
@@ -366,7 +305,59 @@ struct TVSceneDetailView: View {
                         .padding(.vertical, 8)
                     }
                 }
+            }
+            
+            .foregroundColor(.white.opacity(0.9))
+            .padding(.top, 8)
+            
+            // 5. Metadata Line (Duration, Res) + Progress Bar
+            HStack(spacing: 24) {
+                TVStarRatingPill(rating100: scene.rating100) { newRating in
+                    commitRating(scene: scene, newRating: newRating)
+                }
+
+                TVOCountPill(
+                    oCounter: scene.oCounter,
+                    iconName: AppearanceManager.shared.oCounterIconFilled,
+                    onIncrement: { incrementOCount(scene: scene) }
+                )
                 
+                if let duration = scene.sceneDuration, duration > 0 {
+                    HStack(spacing: 6) {
+                        Image(systemName: "clock")
+                        Text(formattedDuration(duration))
+                    }
+                    .font(.headline)
+                }
+
+                if let resolution = resolutionString(for: scene) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "tv")
+                        Text(resolution)
+                    }
+                    .font(.headline)
+                }
+
+                // Progress Bar inline with metadata
+                if let resumeTime = scene.resumeTime, resumeTime > 0, let duration = scene.sceneDuration, duration > 0 {
+                    HStack(spacing: 12) {
+                        Image(systemName: "play.fill")
+                            .font(.caption)
+                        
+                        Text("\(Int(resumeTime / duration * 100))%")
+                            .font(.headline)
+                        
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Rectangle().fill(Color.white.opacity(0.3))
+                                Rectangle().fill(AppearanceManager.shared.tintColor)
+                                    .frame(width: geo.size.width * CGFloat(resumeTime / duration))
+                            }
+                        }
+                        .frame(width: 200, height: 4)
+                        .clipShape(Capsule())
+                    }
+                }
             }
             .padding(.top, 16)
         }
@@ -393,22 +384,20 @@ struct TVSceneDetailView: View {
                 }
 
                 // Rating
-                if let rating100 = scene.rating100, rating100 > 0 {
-                    HStack(spacing: 6) {
-                        ForEach(0..<5, id: \.self) { index in
-                            let starValue = Double(index + 1) * 20.0
-                            let rating = Double(rating100)
-                            Image(systemName: rating >= starValue ? "star.fill" :
-                                  (rating >= starValue - 10 ? "star.leadinghalf.filled" : "star"))
-                                .font(.title3)
-                                .foregroundColor(.yellow)
-                        }
+                HStack(spacing: 6) {
+                    ForEach(0..<5, id: \.self) { index in
+                        let starValue = Double(index + 1) * 20.0
+                        let rating = Double(scene.rating100 ?? 0)
+                        Image(systemName: rating >= starValue ? "star.fill" :
+                              (rating >= starValue - 10 ? "star.leadinghalf.filled" : "star"))
+                            .font(.title3)
+                            .foregroundColor(rating >= starValue ? .yellow : .gray.opacity(0.4))
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(Color.white.opacity(0.06))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Color.white.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
 
                 // Play Count
                 if let playCount = scene.playCount, playCount > 0 {
@@ -416,9 +405,7 @@ struct TVSceneDetailView: View {
                 }
 
                 // O-Counter
-                if let oCounter = scene.oCounter, oCounter > 0 {
-                    metadataPill(icon: "heart.circle", text: "\(oCounter)")
-                }
+                metadataPill(icon: "heart.circle", text: "\(scene.oCounter ?? 0)")
 
                 // Resolution
                 if let file = scene.files?.first, let w = file.width, let h = file.height {
@@ -441,6 +428,34 @@ struct TVSceneDetailView: View {
         .padding(.vertical, 10)
         .background(Color.white.opacity(0.06))
         .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Rating & O-Count
+
+    private func commitRating(scene: Scene, newRating: Int?) {
+        sceneDetail = scene.withRating(newRating)
+        viewModel.updateSceneRating(sceneId: scene.id, rating100: newRating) { success in
+            if !success {
+                DispatchQueue.main.async {
+                    sceneDetail = scene
+                }
+            }
+        }
+    }
+
+    private func incrementOCount(scene: Scene) {
+        let current = scene.oCounter ?? 0
+        sceneDetail = scene.withOCounter(current + 1)
+
+        viewModel.incrementOCounter(sceneId: scene.id) { newCount in
+            if let count = newCount {
+                DispatchQueue.main.async {
+                    if let s = sceneDetail {
+                        sceneDetail = s.withOCounter(count)
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Playback

--- a/stashyTV/TVStarRatingPill.swift
+++ b/stashyTV/TVStarRatingPill.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+struct TVStarRatingPill: View {
+    let rating100: Int?
+    let onRatingCommitted: (Int?) -> Void
+
+    @State private var isEditing = false
+    @State private var editingStars: Int = 0
+    @State private var isFocused = false
+
+    private var currentStars: Int {
+        guard let r = rating100 else { return 0 }
+        return min(5, max(0, Int(round(Double(r) / 20.0))))
+    }
+
+    private var displayStars: Int {
+        isEditing ? editingStars : currentStars
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(1...5, id: \.self) { index in
+                Image(systemName: index <= displayStars ? "star.fill" : "star")
+                    .font(.headline)
+                    .foregroundColor(index <= displayStars ? .yellow : .gray.opacity(0.4))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            isEditing ? Color.yellow.opacity(0.2) :
+                (isFocused ? Color.white.opacity(0.15) : Color.white.opacity(0.06))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(isEditing ? Color.yellow.opacity(0.8) : Color.clear, lineWidth: 2)
+        )
+        .scaleEffect(isFocused ? 1.05 : 1.0)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        .animation(.easeInOut(duration: 0.2), value: isEditing)
+        .animation(.easeInOut(duration: 0.15), value: displayStars)
+        .overlay {
+            RatingFocusInputView(
+                onToggleEdit: { nowEditing in
+                    if nowEditing {
+                        editingStars = currentStars
+                        isEditing = true
+                    } else {
+                        let newRating = editingStars == 0 ? nil : editingStars * 20
+                        onRatingCommitted(newRating)
+                        isEditing = false
+                    }
+                },
+                onAdjustStars: { delta in
+                    editingStars = min(5, max(0, editingStars + delta))
+                },
+                onFocusChange: { focused in
+                    isFocused = focused
+                    if !focused && isEditing {
+                        let newRating = editingStars == 0 ? nil : editingStars * 20
+                        onRatingCommitted(newRating)
+                        isEditing = false
+                    }
+                }
+            )
+        }
+    }
+}
+
+// MARK: - UIKit focus view for D-pad input
+
+private struct RatingFocusInputView: UIViewRepresentable {
+    var onToggleEdit: (Bool) -> Void
+    var onAdjustStars: (Int) -> Void
+    var onFocusChange: (Bool) -> Void
+
+    func makeUIView(context: Context) -> RatingFocusUIView {
+        let view = RatingFocusUIView()
+        view.backgroundColor = .clear
+        view.onToggleEdit = onToggleEdit
+        view.onAdjustStars = onAdjustStars
+        view.onFocusChange = onFocusChange
+        return view
+    }
+
+    func updateUIView(_ uiView: RatingFocusUIView, context: Context) {
+        uiView.onToggleEdit = onToggleEdit
+        uiView.onAdjustStars = onAdjustStars
+        uiView.onFocusChange = onFocusChange
+    }
+}
+
+private final class RatingFocusUIView: UIView {
+    var isEditing = false
+    var onToggleEdit: ((Bool) -> Void)?
+    var onAdjustStars: ((Int) -> Void)?
+    var onFocusChange: ((Bool) -> Void)?
+
+    override var canBecomeFocused: Bool { true }
+
+    override func shouldUpdateFocus(in context: UIFocusUpdateContext) -> Bool {
+        guard isEditing else { return super.shouldUpdateFocus(in: context) }
+        let heading = context.focusHeading
+        if heading.contains(.up) || heading.contains(.down) {
+            isEditing = false
+            return true
+        }
+        return false
+    }
+
+    override func didUpdateFocus(
+        in context: UIFocusUpdateContext,
+        with coordinator: UIFocusAnimationCoordinator
+    ) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        let focused = isFocused
+        if !focused { isEditing = false }
+        onFocusChange?(focused)
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        guard let press = presses.first else {
+            super.pressesBegan(presses, with: event)
+            return
+        }
+        switch press.type {
+        case .select:
+            isEditing.toggle()
+            onToggleEdit?(isEditing)
+        case .leftArrow where isEditing:
+            onAdjustStars?(-1)
+        case .rightArrow where isEditing:
+            onAdjustStars?(1)
+        default:
+            super.pressesBegan(presses, with: event)
+        }
+    }
+}

--- a/stashyTV/TVStudioImageView.swift
+++ b/stashyTV/TVStudioImageView.swift
@@ -129,10 +129,35 @@ private struct TVPocketSVGView: UIViewRepresentable {
     func updateUIView(_ uiView: SVGImageView, context: Context) {
         uiView.contentMode = (contentMode == .fill) ? .scaleAspectFill : .scaleAspectFit
         uiView.layer.contentsGravity = (contentMode == .fill) ? .resizeAspectFill : .resizeAspect
-        uiView.paths = SVGBezierPath.paths(fromSVGString: svgString)
-        // Force a layout pass so the layer scales to the SwiftUI-provided bounds.
+        uiView.paths = SVGBezierPath.paths(fromSVGString: Self.sanitizeSVGColors(svgString))
         uiView.setNeedsLayout()
         uiView.layoutIfNeeded()
         uiView.setNeedsDisplay()
+    }
+
+    // PocketSVG's hexTriplet parser only handles named SVG colors, #hex, and rgb().
+    // It crashes on rgba(), currentColor, transparent, inherit, url(), hsl(), etc.
+    static func sanitizeSVGColors(_ svg: String) -> String {
+        var result = svg
+        result = result.replacingOccurrences(
+            of: #"rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*[\d.]+\s*\)"#,
+            with: "rgb($1,$2,$3)",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"hsla?\([^)]*\)"#,
+            with: "#000000",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"url\([^)]*\)"#,
+            with: "none",
+            options: .regularExpression
+        )
+        let keywords = ["transparent", "currentColor", "currentcolor", "inherit"]
+        for keyword in keywords {
+            result = result.replacingOccurrences(of: keyword, with: keyword == "transparent" ? "none" : "#000000")
+        }
+        return result
     }
 }


### PR DESCRIPTION
This PR adds a few new features to tvOS.

- KSPlayer with extended seek features:
  
  Using KSPlayer in tvOS allows playing AV1 and other non-native codec
  playback on all Apple TV models. In addition "extended seek" features
  where added to the player. In "fast seek" mode it displays the
  SpritePreview images from the stash server (press PAUSE for "fast
  seek").

- add interactive rating and O-count pills

  Update rating and O-Count with the remote

- show video preview on scene cards

   Show the animated preview from the stash server for the selected scene

And there is a small bugfix to prevent SVG images with transparent background
from crashing the app. 

Please not that the first tvOS commit requires my changes from #9 for the sprite preview.
